### PR TITLE
Add MOOSE segmentation JSON (dataset.json) format support directly

### DIFF
--- a/nifti2dicom/converter.py
+++ b/nifti2dicom/converter.py
@@ -286,7 +286,7 @@ def main():
             os.makedirs(args.output_dir)
         with open(args.json, 'r') as f:
             organ_index = json.load(f)
-             if args.moose == 'True':
+            if args.moose == 'True':
                 organ_index = moose_json_convertor(organ_index)        
         save_dicom_from_nifti_seg(args.nifti_path, args.dicom_dir, args.output_dir, organ_index)
     elif args.type == 'seg' and not args.json: # if the type is segmentation and the json file is not provided

--- a/nifti2dicom/converter.py
+++ b/nifti2dicom/converter.py
@@ -249,10 +249,12 @@ def save_dicom_from_nifti_seg(nifti_file: str, ref_dicom_series_dir: str, output
     seg.save_as(os.path.join(output_path, os.path.basename(nifti_file) + ".dcm"))
 
 def moose_json_convertor(input_data):
-    label_data = input_data.get("label", {})
-    formatted_data = {str(value): key for key, value in label_data.items()}
+    label_data = input_data.get("labels", {})
+    formatted_data = {
+        str(value): key for key, value in label_data.items() if key != "background"
+    }
     return formatted_data
-    
+
 def main():
     import argparse
 
@@ -287,7 +289,7 @@ def main():
         with open(args.json, 'r') as f:
             organ_index = json.load(f)
             if args.moose == 'True':
-                organ_index = moose_json_convertor(organ_index)        
+                organ_index = moose_json_convertor(organ_index)             
         save_dicom_from_nifti_seg(args.nifti_path, args.dicom_dir, args.output_dir, organ_index)
     elif args.type == 'seg' and not args.json: # if the type is segmentation and the json file is not provided
         raise ValueError(f"Please provide a JSON file containing the label to region index.")

--- a/nifti2dicom/converter.py
+++ b/nifti2dicom/converter.py
@@ -248,7 +248,11 @@ def save_dicom_from_nifti_seg(nifti_file: str, ref_dicom_series_dir: str, output
     # Save the DICOM SEG object with same filename as NIFTI file
     seg.save_as(os.path.join(output_path, os.path.basename(nifti_file) + ".dcm"))
 
-
+def moose_json_convertor(input_data):
+    label_data = input_data.get("label", {})
+    formatted_data = {str(value): key for key, value in label_data.items()}
+    return formatted_data
+    
 def main():
     import argparse
 
@@ -265,6 +269,7 @@ def main():
     parser.add_argument("-v", "--vendor", type=str, choices=['sms', 'ux'], required=False, default='ux',
                         help="Vendor of the reference DICOM series.")
     parser.add_argument("-j", "--json", type=str, help=f"Path to the JSON file containing the label to region index. ")
+    parser.add_argument("-m", "--moose", type=str, choices=['True', 'False'], required=False, default='False')
     
 
 
@@ -281,6 +286,8 @@ def main():
             os.makedirs(args.output_dir)
         with open(args.json, 'r') as f:
             organ_index = json.load(f)
+             if args.moose == 'True':
+                organ_index = moose_json_convertor(organ_index)        
         save_dicom_from_nifti_seg(args.nifti_path, args.dicom_dir, args.output_dir, organ_index)
     elif args.type == 'seg' and not args.json: # if the type is segmentation and the json file is not provided
         raise ValueError(f"Please provide a JSON file containing the label to region index.")


### PR DESCRIPTION
This patch will use dataset.json from a [MOOSE](https://github.com/LalithShiyam/MOOSE) segmentation directly. It will convert the input JSON data to suit [nifti2dicom input JSON format](https://github.com/LalithShiyam/nifti2dicom/blob/main/labels_region.json) on the fly.

Usage:
Added new argument "-m" or "--moose", conversion will apply when it is true. `-m True`
```
parser.add_argument("-m", "--moose", type=str, choices=['True', 'False'], required=False, default='False')
```


Sample Input dataset.json : 

```
{'name': 'Dataset001_PUMA', 'description': '', 'reference': '', 'licence': 'hands off!', 'release': '0.0', 'labels': {'background': 0, 'legs': 1, 'body': 2, 'head': 3, 'arms': 4}, 'numTraining': 121, 'file_ending': '.nii.gz', 'channel_names': {'0': 'CT'}}
```

Sample conversion at organ_index:

```
{'1': 'legs', '2': 'body', '3': 'head', '4': 'arms'}
```