### PR TITLE
Code clean up and optional header transfer

### DIFF
--- a/nifti2dicom/constants.py
+++ b/nifti2dicom/constants.py
@@ -20,4 +20,7 @@ ANSI_VIOLET = '\033[38;5;141m'
 ANSI_RESET = '\033[0m'
 
 
+TAGS_TO_EXCLUDE = ["Pixel Data", "Image Index", "Number of Slices", "Rows", "Columns", 'Pixel Spacing',
+                   "Image Position (Patient)", "Image Orientation (Patient)", "Instance Number", "Slice Thickness",
+                   "Slice Location"]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='nifti2dicom',
-    version='1.1.4',
+    version='1.1.5',
     packages=find_packages(),
     install_requires=[
         'pydicom',


### PR DESCRIPTION
**Description**
To accompany `pumaz`-aligned PET images and convert them back into an aligned DICOM image with the same information as the original DICOM image, an optional mode was implemented by passing `-hd` with the directory the original header information will be taken from. `-d` acts as a reference for the spatial information of the image.

**Changes**
converter.py
- cleaned up code and improved readability. This encompasses formatting fixes and removing unneeded code segments, such as the determination of labels in `save_dicom_from_nifti_seg()` and the unused attribute vendor in `save_slice()`. The vendor check for 3D images was also removed, as this was always evaluated as `True` in the implementation and was not deterministic for the code's behavior.
- improved variable and attribute names
- renamed `load_reference_dicom_series()` to `load_dicom_series()`
- added an optional parameter to `save_slice()` and `save_dicom_from_nifti_image()` to copy header information from a second dicom series to the header of the reference series. This is useful when processing on the nifti image was done, and the reference header contains the spatial information, whereas the second header contains the actual study information. 

setup.py
- raised version to 1.1.5 

constants.py
- added `TAGS_TO_EXCLUDE` to `constants.py`. These tags will not be copied to the spatial reference header.

**Tests**
Tested with header transfer and without header transfer.