### PR TITLE
Support pydicom 3

### DIFF
--- a/nifti2dicom/converter.py
+++ b/nifti2dicom/converter.py
@@ -29,7 +29,7 @@ import pydicom
 from nifti2dicom.constants import ANSI_ORANGE, ANSI_GREEN, ANSI_VIOLET, ANSI_RESET, TAGS_TO_EXCLUDE
 from nifti2dicom.display import display_welcome_message
 from pydicom.dataset import Dataset, FileMetaDataset
-from pydicom.filewriter import write_file
+from pydicom.filewriter import dcmwrite
 from pydicom.sr.codedict import codes
 from pydicom.uid import ExplicitVRLittleEndian, generate_uid
 from rich.progress import Progress, track
@@ -225,7 +225,7 @@ def write_rgb_dicom_from_nifti(nifti_file_path, reference_dicom_series, output_d
             ds.PatientName = metadata.PatientName
             ds.PatientID = metadata.PatientID
             ds.PatientBirthDate = metadata.PatientBirthDate
-            write_file(dicom_filename, ds, write_like_original=False)
+            dcmwrite(dicom_filename, ds, write_like_original=False)
             progress.update(task, advance=1, description=f"[white] Writing RGB DICOM slices... [{i}/{total_slices}]")
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,8 @@ setup(
     install_requires=[
         'nibabel',
         'SimpleITK',
-        'numpy',
         'emoji',
         'rich',
-        'pydicom<3.0',
         'highdicom',
         'pyfiglet'
     ],


### PR DESCRIPTION
Attempts to resolve build issues in #29
- `pydicom.filewriter.write_file` was deprecated. It is replaced for pydicom 3 support,
- `pydicom` and `numpy` dependencies are hidden, as they are subdependencies of other requirements

Please verify if new `dcmwrite` function works as it is supposed to. It does not cover my use case, but documentations suggests it should.